### PR TITLE
Fix for popular site issue

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -58,12 +58,19 @@
           </div>
         {{ end }}
       </div>
+
+      
     </div>
+    {{ $popularJson := $.Site.Data.popular }}
+    {{ $popular := slice }}
+    {{ if $popularJson }}
+      {{ $popular = $popularJson }}
+
     <div class="row">
       <h1>Popular</h1>
     </div>
     <div class="row">
-      {{ $popular := $.Site.Data.popular | first 3 }}
+    {{ end }}
       {{ range where $.Site.RegularPages "RelPermalink" "in" $popular }}
         <div class="px-0 px-lg-2 mh-100 h-100 col-lg-4 col-sm-12 my-2">
           <a href="{{ .Permalink }}" class="card bg-cwc text-white">


### PR DESCRIPTION
# Description

This PR fixes the issue identified in #125 by @SamGreenwood1. If a site was built using the theme and did not have an empty array in the data/popular.json file, then the site would not build.

Logic has been adjusted to account for this.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Maintenance / Chore (Something which is needed to enable the project broadly)

# How Has This Been Tested?

Manual tests.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- This change is:
  - [ ] Not updating Site/Page Metadata/Frontmatter
  - [ ] Updating Site/Page Metadata/Frontmatter and the JSON-LD site_metadata partial has been reviewed for correctness